### PR TITLE
end stream on !readable

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function read(stream, cb) {
 };
 
 function read1(stream, cb) {
-  if (!stream.readable) return cb();
+  if (!stream.readable) return cb(null, null);
 
   stream.on('data', ondata);
   stream.on('error', onerror);
@@ -39,7 +39,7 @@ function read1(stream, cb) {
 }
 
 function read2(stream, cb) {
-  if (!stream.readable) return cb();
+  if (!stream.readable) return cb(null, null);
   var ended = false;
 
   function onreadable() {


### PR DESCRIPTION
I'm running into an issue where the (undocumented?) `readable` property of a readable stream is false when the stream ends, causing [this condition](https://github.com/micnews/stream-read/blob/master/index.js#L42) to be true. Because the stream has ended, the callback should be called with `null` data to indicate such.
